### PR TITLE
Fix getAuthUser. all users were getting same data

### DIFF
--- a/api/src/resolvers/user.ts
+++ b/api/src/resolvers/user.ts
@@ -28,7 +28,7 @@ const UserResolver: Resolvers = {
       if (!authUser) return null;
 
       // If user is authenticated, update it's isOnline field to true
-      const user = await User.findOneAndUpdate({ id: authUser.id }, { isOnline: true })
+      const user = await User.findOneAndUpdate({ _id: authUser._id }, { isOnline: true })
         .populate({ path: 'posts', options: { sort: { createdAt: 'desc' } } })
         .populate('likes')
         .populate('followers')


### PR DESCRIPTION
All users were getting the same data (latest user in collection).
It was equivalent to data returned by User.findOneAndUpdate({ }, {  isOnline: true })  which returns latest user in the collection by default.

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [x] api
- [ ] frontend
- [ ] lib
